### PR TITLE
Add index option to select, multi-select and sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*.rs", "Cargo.toml", "LICENSE", "*.md"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-dialoguer = "0.7.0"
+dialoguer = "0.8.0"
 structopt = "0.3.7"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Prompt that allows the user to select from a list of options
 #### Usage
 
 ```
-enquirer-select 0.3.0
+enquirer-select 0.5.0
 Prompt that allows the user to select from a list of options
 
 USAGE:
@@ -223,6 +223,7 @@ USAGE:
 
 FLAGS:
     -h, --help     Prints help information
+    -i, --index    Returns index of the selected item instead of item itself
     -p, --paged    Enables paging. Uses your terminal size
 
 OPTIONS:
@@ -244,7 +245,7 @@ Prompt that allows the user to select multiple items from a list of options
 #### Usage
 
 ```
-enquirer-multi-select 0.3.0
+enquirer-multi-select 0.5.0
 Prompt that allows the user to select multiple items from a list of options
 
 USAGE:
@@ -252,6 +253,7 @@ USAGE:
 
 FLAGS:
     -h, --help         Prints help information
+    -i, --index        Returns index of the selected items instead of items itself
         --no-inline    Do not print the selected items on the prompt line
     -p, --paged        Enables paging. Uses your terminal size
 
@@ -274,7 +276,7 @@ Prompt that allows the user to sort items in a list
 #### Usage
 
 ```
-enquirer-sort 0.3.0
+enquirer-sort 0.5.0
 Prompt that allows the user to sort items in a list
 
 USAGE:
@@ -282,6 +284,7 @@ USAGE:
 
 FLAGS:
     -h, --help         Prints help information
+    -i, --index        Returns index of the sorted items instead of items itself
         --no-inline    Do not print the sorted items on the prompt line
     -p, --paged        Enables paging. Uses your terminal size
 

--- a/src/multi_select.rs
+++ b/src/multi_select.rs
@@ -14,6 +14,10 @@ pub struct MultiSelect {
     #[structopt(short, long)]
     paged: bool,
 
+    /// Returns index of the selected items instead of items itself
+    #[structopt(short, long)]
+    index: bool,
+
     /// Do not print the selected items on the prompt line
     #[structopt(long)]
     no_inline: bool,
@@ -61,8 +65,14 @@ impl MultiSelect {
 
         let value = input.interact()?;
 
-        for i in value {
-            println!("{}", self.items[i]);
+        if self.index {
+            for i in value {
+                println!("{}", i);
+            }
+        } else {
+            for i in value {
+                println!("{}", self.items[i]);
+            }
         }
 
         Ok(())

--- a/src/select.rs
+++ b/src/select.rs
@@ -14,6 +14,10 @@ pub struct Select {
     #[structopt(short, long)]
     paged: bool,
 
+    /// Returns index of the selected item instead of item itself
+    #[structopt(short, long)]
+    index: bool,
+
     /// Specify number of the item that will be selected by default
     #[structopt(short, long)]
     selected: Option<usize>,
@@ -45,7 +49,11 @@ impl Select {
 
         let value = input.interact()?;
 
-        println!("{}", self.items[value]);
+        if self.index {
+            println!("{}", value);
+        } else {
+            println!("{}", self.items[value]);
+        }
 
         Ok(())
     }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -14,6 +14,10 @@ pub struct Sort {
     #[structopt(short, long)]
     paged: bool,
 
+    /// Returns index of the selected item instead of item itself
+    #[structopt(short, long)]
+    index: bool,
+
     /// Do not print the sorted items on the prompt line
     #[structopt(long)]
     no_inline: bool,
@@ -45,8 +49,14 @@ impl Sort {
 
         let value = input.interact()?;
 
-        for i in value {
-            println!("{}", self.items[i]);
+        if self.index {
+            for i in value {
+                println!("{}", i);
+            }
+        } else {
+            for i in value {
+                println!("{}", self.items[i]);
+            }
         }
 
         Ok(())

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -14,7 +14,7 @@ pub struct Sort {
     #[structopt(short, long)]
     paged: bool,
 
-    /// Returns index of the selected item instead of item itself
+    /// Returns index of the sorted items instead of items itself
     #[structopt(short, long)]
     index: bool,
 


### PR DESCRIPTION
Closes #11. Simple addition of `-i|--index` option to the select, sort and multi-select prompts.