### PR TITLE
draft: add --cancel and --default to respective prompts (reflect changes from latest dialoguer)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*.rs", "Cargo.toml", "LICENSE", "*.md"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-dialoguer = "0.8.0"
+dialoguer = "0.9.0"
 structopt = "0.3.7"
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ fi
 See [prompts](#prompts) for more information on subcommands.
 
 ```
-enquirer 0.3.0
+enquirer 0.5.1
 Command Line Utility for Stylish Interactive Prompts
 
 USAGE:
@@ -99,7 +99,7 @@ If you want the dialoguer theme used in this tool you can add this package to yo
 
 ```rust
 use dialoguer::Confirmation;
-use enquirer::ColoredTheme;
+use dialoguer::theme::ColoredTheme;
 
 fn main() {
     let prompt = Confirmation::with_theme(&ColoredTheme::default())
@@ -134,18 +134,19 @@ Prompt that returns `true` or `false` (as strings)
 #### Usage
 
 ```
-enquirer-confirm 0.3.0
+enquirer-confirm 0.5.1
 Prompt that returns `true` or `false` (as strings)
 
 USAGE:
-    enquirer confirm [FLAGS] [OPTIONS] --message <message>
+    enquirer confirm [FLAGS] --message <message>
 
 FLAGS:
+    -c, --cancel     Makes the prompt cancellable with 'Esc' or 'q'
     -d, --default    Default value for the prompt is `true`
     -h, --help       Prints help information
 
 OPTIONS:
-    -m, --message <message>      Message for the prompt
+    -m, --message <message>    Message for the prompt
 ```
 
 ### Input Prompt
@@ -159,7 +160,7 @@ Prompt that takes user input and returns a string
 #### Usage
 
 ```
-enquirer-input 0.3.0
+enquirer-input 0.5.1
 Prompt that takes user input and returns a string
 
 USAGE:
@@ -185,7 +186,7 @@ Prompt that takes user input, hides it from the terminal, and returns a string
 #### Usage
 
 ```
-enquirer-secret 0.3.0
+enquirer-secret 0.5.1
 Prompt that takes user input, hides it from the terminal, and returns a string
 
 USAGE:
@@ -212,16 +213,16 @@ Prompt that allows the user to select from a list of options
 #### Usage
 
 ```
-enquirer-select 0.5.0
+enquirer-select 0.5.1
 Prompt that allows the user to select from a list of options
 
 USAGE:
     enquirer select [FLAGS] [OPTIONS] --message <message> [items]...
 
 FLAGS:
-    -h, --help     Prints help information
-    -i, --index    Returns index of the selected item instead of item itself
-    -p, --paged    Enables paging. Uses your terminal size
+    -c, --cancel    Makes the prompt cancellable with 'Esc' or 'q'
+    -h, --help      Prints help information
+    -i, --index     Returns index of the selected item instead of item itself
 
 OPTIONS:
     -m, --message <message>      Message for the prompt
@@ -242,17 +243,19 @@ Prompt that allows the user to select multiple items from a list of options
 #### Usage
 
 ```
-enquirer-multi-select 0.5.0
+enquirer-multi-select 0.5.1
 Prompt that allows the user to select multiple items from a list of options
 
 USAGE:
     enquirer multi-select [FLAGS] [OPTIONS] --message <message> [--] [items]...
 
 FLAGS:
+    -c, --cancel       Makes the prompt cancellable with 'Esc' or 'q'
     -h, --help         Prints help information
     -i, --index        Returns index of the selected items instead of items itself
         --no-inline    Do not print the selected items on the prompt line
-    -p, --paged        Enables paging. Uses your terminal size
+    -d, --default      Makes the prompt return default values provided with --selected option if --cancel option is
+                       present
 
 OPTIONS:
     -m, --message <message>         Message for the prompt
@@ -273,17 +276,18 @@ Prompt that allows the user to sort items in a list
 #### Usage
 
 ```
-enquirer-sort 0.5.0
+enquirer-sort 0.5.1
 Prompt that allows the user to sort items in a list
 
 USAGE:
     enquirer sort [FLAGS] --message <message> [items]...
 
 FLAGS:
+    -c, --cancel       Makes the prompt cancellable with 'Esc' or 'q'
     -h, --help         Prints help information
     -i, --index        Returns index of the sorted items instead of items itself
         --no-inline    Do not print the sorted items on the prompt line
-    -p, --paged        Enables paging. Uses your terminal size
+    -d, --default      Makes the prompt return default order as given if --cancel option is present
 
 OPTIONS:
     -m, --message <message>    Message for the prompt

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -10,7 +10,7 @@ pub struct Confirm {
     #[structopt(short, long)]
     message: String,
 
-    /// Makes the prompt cancellable with 'Esc' or 'q'.
+    /// Makes the prompt cancellable with 'Esc' or 'q'
     #[structopt(short, long)]
     cancel: bool,
 
@@ -38,7 +38,7 @@ impl Confirm {
 
         let value = match ret {
             Some(value) => value,
-            None => self.default,
+            None => std::process::exit(1),
         };
 
         if value {

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -32,7 +32,7 @@ impl Confirm {
         let ret = if self.cancel {
             input.interact_opt()?
         } else {
-            Some(input.interact()?)
+            input.interact().ok()
         };
 
         let value = match ret {

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -10,6 +10,10 @@ pub struct Confirm {
     #[structopt(short, long)]
     message: String,
 
+    /// Makes the prompt cancellable with 'Esc' or 'q'.
+    #[structopt(short, long)]
+    cancel: bool,
+
     /// Default value for the prompt is `true`
     #[structopt(short, long)]
     default: bool,
@@ -21,10 +25,20 @@ pub struct Confirm {
 
 impl Confirm {
     pub fn run(&self) -> Result<()> {
-        let value = dialoguer::Confirm::with_theme(&ColorfulTheme::default())
+        let input = dialoguer::Confirm::with_theme(&ColorfulTheme::default())
             .with_prompt(&self.message)
-            .default(self.default)
-            .interact()?;
+            .default(self.default);
+
+        let ret = if self.cancel {
+            input.interact_opt()?
+        } else {
+            Some(input.interact()?)
+        };
+
+        let value = match ret {
+            Some(value) => value,
+            None => self.default,
+        };
 
         if value {
             println!("true");

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -27,10 +27,8 @@ impl Confirm {
     pub fn run(&self) -> Result<()> {
         let theme = ColorfulTheme::default();
         let mut input = dialoguer::Confirm::with_theme(&theme);
-            
-        input
-            .with_prompt(&self.message)
-            .default(self.default);
+
+        input.with_prompt(&self.message).default(self.default);
 
         let ret = if self.cancel {
             input.interact_opt()?

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -25,14 +25,17 @@ pub struct Confirm {
 
 impl Confirm {
     pub fn run(&self) -> Result<()> {
-        let input = dialoguer::Confirm::with_theme(&ColorfulTheme::default())
+        let theme = ColorfulTheme::default();
+        let mut input = dialoguer::Confirm::with_theme(&theme);
+            
+        input
             .with_prompt(&self.message)
             .default(self.default);
 
         let ret = if self.cancel {
             input.interact_opt()?
         } else {
-            input.interact().ok()
+            Some(input.interact()?)
         };
 
         let value = match ret {

--- a/src/multi_select.rs
+++ b/src/multi_select.rs
@@ -10,10 +10,6 @@ pub struct MultiSelect {
     #[structopt(short, long)]
     message: String,
 
-    /// Enables paging. Uses your terminal size
-    #[structopt(short, long)]
-    paged: bool,
-
     /// Makes the prompt cancellable with 'Esc' or 'q'.
     #[structopt(short, long)]
     cancel: bool,
@@ -66,7 +62,6 @@ impl MultiSelect {
 
         input
             .with_prompt(&self.message)
-            .paged(self.paged)
             .clear(true)
             .items(&self.items)
             .defaults(&defaults);
@@ -74,7 +69,7 @@ impl MultiSelect {
         let ret = if self.cancel {
             input.interact_opt()?
         } else {
-            input.interact().ok()
+            Some(input.interact()?)
         };
 
         let value = match ret {

--- a/src/multi_select.rs
+++ b/src/multi_select.rs
@@ -74,7 +74,7 @@ impl MultiSelect {
         let ret = if self.cancel {
             input.interact_opt()?
         } else {
-            Some(input.interact()?)
+            input.interact().ok()
         };
 
         let value = match ret {

--- a/src/multi_select.rs
+++ b/src/multi_select.rs
@@ -10,11 +10,11 @@ pub struct MultiSelect {
     #[structopt(short, long)]
     message: String,
 
-    /// Makes the prompt cancellable with 'Esc' or 'q'.
+    /// Makes the prompt cancellable with 'Esc' or 'q'
     #[structopt(short, long)]
     cancel: bool,
 
-    /// Makes the prompt return default values provided with --selected option if --cancel option is present.
+    /// Makes the prompt return default values provided with --selected option if --cancel option is present
     #[structopt(short = "d", long = "default")]
     return_default: bool,
 

--- a/src/multi_select.rs
+++ b/src/multi_select.rs
@@ -14,7 +14,7 @@ pub struct MultiSelect {
     #[structopt(short, long)]
     cancel: bool,
 
-    /// Makes the prompt return default values provided with --selected option if --cancel option is present
+    /// Makes the prompt return default values as given if --cancel option is present
     #[structopt(short = "d", long = "default")]
     return_default: bool,
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -10,7 +10,7 @@ pub struct Select {
     #[structopt(short, long)]
     message: String,
 
-    /// Makes the prompt cancellable with 'Esc' or 'q'.
+    /// Makes the prompt cancellable with 'Esc' or 'q'
     #[structopt(short, long)]
     cancel: bool,
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -14,6 +14,10 @@ pub struct Select {
     #[structopt(short, long)]
     paged: bool,
 
+    /// Makes the prompt cancellable with 'Esc' or 'q'.
+    #[structopt(short, long)]
+    cancel: bool,
+
     /// Returns index of the selected item instead of item itself
     #[structopt(short, long)]
     index: bool,
@@ -47,7 +51,16 @@ impl Select {
             input.default(self.selected.unwrap() - 1);
         }
 
-        let value = input.interact()?;
+        let ret = if self.cancel {
+            input.interact_opt()?
+        } else {
+            Some(input.interact()?)
+        };
+
+        let value = match ret {
+            Some(value) => value,
+            None => std::process::exit(1),
+        };
 
         if self.index {
             println!("{}", value);

--- a/src/select.rs
+++ b/src/select.rs
@@ -54,7 +54,7 @@ impl Select {
         let ret = if self.cancel {
             input.interact_opt()?
         } else {
-            Some(input.interact()?)
+            input.interact().ok()
         };
 
         let value = match ret {

--- a/src/select.rs
+++ b/src/select.rs
@@ -10,10 +10,6 @@ pub struct Select {
     #[structopt(short, long)]
     message: String,
 
-    /// Enables paging. Uses your terminal size
-    #[structopt(short, long)]
-    paged: bool,
-
     /// Makes the prompt cancellable with 'Esc' or 'q'.
     #[structopt(short, long)]
     cancel: bool,
@@ -43,7 +39,6 @@ impl Select {
 
         input
             .with_prompt(&self.message)
-            .paged(self.paged)
             .clear(true)
             .items(&self.items);
 
@@ -54,7 +49,7 @@ impl Select {
         let ret = if self.cancel {
             input.interact_opt()?
         } else {
-            input.interact().ok()
+            Some(input.interact()?)
         };
 
         let value = match ret {

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -10,11 +10,11 @@ pub struct Sort {
     #[structopt(short, long)]
     message: String,
 
-    /// Makes the prompt cancellable with 'Esc' or 'q'.
+    /// Makes the prompt cancellable with 'Esc' or 'q'
     #[structopt(short, long)]
     cancel: bool,
 
-    /// Makes the prompt return default order as given if --cancel option is present.
+    /// Makes the prompt return default order as given if --cancel option is present
     #[structopt(short = "d", long = "default")]
     return_default: bool,
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -10,10 +10,6 @@ pub struct Sort {
     #[structopt(short, long)]
     message: String,
 
-    /// Enables paging. Uses your terminal size
-    #[structopt(short, long)]
-    paged: bool,
-
     /// Makes the prompt cancellable with 'Esc' or 'q'.
     #[structopt(short, long)]
     cancel: bool,
@@ -51,19 +47,18 @@ impl Sort {
 
         input
             .with_prompt(&self.message)
-            .paged(self.paged)
             .clear(true)
             .items(&self.items);
 
         let ret = if self.cancel {
             input.interact_opt()?
         } else {
-            input.interact().ok()
+            Some(input.interact()?)
         };
 
         let value = match ret {
             Some(value) => value,
-            None if self.return_default => 0..self.items.len(),
+            None if self.return_default => (0..self.items.len()).collect(),
             None => std::process::exit(1),
         };
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -58,7 +58,7 @@ impl Sort {
         let ret = if self.cancel {
             input.interact_opt()?
         } else {
-            Some(input.interact()?)
+            input.interact().ok()
         };
 
         let value = match ret {


### PR DESCRIPTION
Closes #8 and closes #9.

Won't build until dialoguer release happen containing mitsuhiko/dialoguer#136, will update the README.md then.

(I'm not too sure if there's a way to reduce options in the code, they consume ~10 lines :sweat_smile: :sweat_smile:)